### PR TITLE
sed changes to debian/letsencrypt.sh

### DIFF
--- a/debian/resources/letsencrypt.sh
+++ b/debian/resources/letsencrypt.sh
@@ -58,8 +58,8 @@ cp docs/examples/config /etc/dehydrated
 
 #update the dehydrated config
 #sed "s#CONTACT_EMAIL=#CONTACT_EMAIL=$email_address" -i /etc/dehydrated/config
-sed -i' ' -e s:'#CONTACT_EMAIL=":CONTACT_EMAIL=$email_address:' /etc/dehydrated/config
-sed -i' ' -e s:'#WELLKNOWN="/var/www/dehydrated":WELLKNOWN="/var/www/dehydrated":' /etc/dehydrated/config
+sed -i 's/#CONTACT_EMAIL=/CONTACT_EMAIL="'"$email_address"'"/g' /etc/dehydrated/config
+sed -i 's/#WELLKNOWN=/WELLKNOWN=/g' /etc/dehydrated/config
 
 #accept the terms
 dehydrated --register --accept-terms --config /etc/dehydrated/config


### PR DESCRIPTION
fix for sed entries to modify the config file. 1)current sed entries generates 2 files, one with a trailing space. 2) email is not updated on config file. fixed issue passing variables and adding quotes around email address. 3) shortened removing # in WELLKNOWN as file path does not change. Also, this line may be causing duplicate files